### PR TITLE
style(templates:coffee): cleanup & consistency fix of .coffee files

### DIFF
--- a/templates/controller/name.controller.coffee
+++ b/templates/controller/name.controller.coffee
@@ -1,4 +1,5 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller '<%= classedName %>Ctrl', ($scope) ->
+angular.module '<%= scriptAppName %>'
+.controller '<%= classedName %>Ctrl', ($scope) ->
   $scope.message = 'Hello'

--- a/templates/controller/name.controller.spec.coffee
+++ b/templates/controller/name.controller.spec.coffee
@@ -3,16 +3,15 @@
 describe 'Controller: <%= classedName %>Ctrl', ->
 
   # load the controller's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
   <%= classedName %>Ctrl = undefined
   scope = undefined
 
   # Initialize the controller and a mock scope
-  beforeEach inject(($controller, $rootScope) ->
+  beforeEach inject ($controller, $rootScope) ->
     scope = $rootScope.$new()
-    <%= classedName %>Ctrl = $controller('<%= classedName %>Ctrl',
+    <%= classedName %>Ctrl = $controller '<%= classedName %>Ctrl',
       $scope: scope
-    )
-  )
+
   it 'should ...', ->
     expect(1).toEqual 1

--- a/templates/decorator/name.decorator.coffee
+++ b/templates/decorator/name.decorator.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module("<%= scriptAppName %>").config ($provide) ->
-  $provide.decorator "<%= cameledName %>", ($delegate) ->
+angular.module '<%= scriptAppName %>'
+.config ($provide) ->
+  $provide.decorator '<%= cameledName %>', ($delegate) ->
     # decorate the $delegate
     $delegate

--- a/templates/directiveComplex/name.directive.coffee
+++ b/templates/directiveComplex/name.directive.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').directive '<%= cameledName %>', ->
+angular.module '<%= scriptAppName %>'
+.directive '<%= cameledName %>', ->
   templateUrl: '<%= htmlUrl %>'
   restrict: 'EA'
   link: (scope, element, attrs) ->

--- a/templates/directiveComplex/name.directive.spec.coffee
+++ b/templates/directiveComplex/name.directive.spec.coffee
@@ -3,16 +3,16 @@
 describe 'Directive: <%= cameledName %>', ->
 
   # load the directive's module and view
-  beforeEach module('<%= scriptAppName %>')
-  beforeEach module('<%= htmlUrl %>')
+  beforeEach module '<%= scriptAppName %>'
+  beforeEach module '<%= htmlUrl %>'
   element = undefined
   scope = undefined
-  beforeEach inject(($rootScope) ->
+  beforeEach inject ($rootScope) ->
     scope = $rootScope.$new()
-  )
-  it 'should make hidden element visible', inject(($compile) ->
-    element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>')
-    element = $compile(element)(scope)
+
+  it 'should make hidden element visible', inject ($compile) ->
+    element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
+    element = $compile(element) scope
     scope.$apply()
     expect(element.text()).toBe 'this is the <%= cameledName %> directive'
-  )
+

--- a/templates/directiveSimple/name.directive.coffee
+++ b/templates/directiveSimple/name.directive.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').directive '<%= cameledName %>', ->
+angular.module '<%= scriptAppName %>'
+.directive '<%= cameledName %>', ->
   template: '<div></div>'
   restrict: 'EA'
   link: (scope, element, attrs) ->

--- a/templates/directiveSimple/name.directive.spec.coffee
+++ b/templates/directiveSimple/name.directive.spec.coffee
@@ -3,14 +3,13 @@
 describe 'Directive: <%= cameledName %>', ->
 
   # load the directive's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
   element = undefined
   scope = undefined
-  beforeEach inject(($rootScope) ->
+  beforeEach inject ($rootScope) ->
     scope = $rootScope.$new()
-  )
-  it 'should make hidden element visible', inject(($compile) ->
-    element = angular.element('<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>')
-    element = $compile(element)(scope)
+
+  it 'should make hidden element visible', inject ($compile) ->
+    element = angular.element '<<%= _.dasherize(name) %>></<%= _.dasherize(name) %>>'
+    element = $compile(element) scope
     expect(element.text()).toBe 'this is the <%= cameledName %> directive'
-  )

--- a/templates/factory/name.service.coffee
+++ b/templates/factory/name.service.coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').factory '<%= cameledName %>', ->
+angular.module '<%= scriptAppName %>'
+.factory '<%= cameledName %>', ->
 
   # Service logic
   # ...

--- a/templates/factory/name.service.spec.coffee
+++ b/templates/factory/name.service.spec.coffee
@@ -3,12 +3,12 @@
 describe 'Service: <%= cameledName %>', ->
 
   # load the service's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
   <%= cameledName %> = undefined
-  beforeEach inject((_<%= cameledName %>_) ->
+  beforeEach inject (_<%= cameledName %>_) ->
     <%= cameledName %> = _<%= cameledName %>_
-  )
+
   it 'should do something', ->
     expect(!!<%= cameledName %>).toBe true

--- a/templates/filter/name.filter.coffee
+++ b/templates/filter/name.filter.coffee
@@ -1,5 +1,6 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').filter '<%= cameledName %>', ->
+angular.module '<%= scriptAppName %>'
+.filter '<%= cameledName %>', ->
   (input) ->
     '<%= cameledName %> filter: ' + input

--- a/templates/filter/name.filter.spec.coffee
+++ b/templates/filter/name.filter.spec.coffee
@@ -3,13 +3,13 @@
 describe 'Filter: <%= cameledName %>', ->
 
   # load the filter's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
 
   # initialize a new instance of the filter before each test
   <%= cameledName %> = undefined
-  beforeEach inject(($filter) ->
-    <%= cameledName %> = $filter('<%= cameledName %>')
-  )
+  beforeEach inject ($filter) ->
+    <%= cameledName %> = $filter '<%= cameledName %>'
+
   it 'should return the input prefixed with \'<%= cameledName %> filter:\'', ->
     text = 'angularjs'
-    expect(<%= cameledName %>(text)).toBe '<%= cameledName %> filter: ' + text
+    expect(<%= cameledName %> text).toBe '<%= cameledName %> filter: ' + text

--- a/templates/provider/name.service.coffee
+++ b/templates/provider/name.service.coffee
@@ -1,22 +1,22 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>')
-  .provider '<%= cameledName %>', ->
+angular.module '<%= scriptAppName %>'
+.provider '<%= cameledName %>', ->
 
-    # Private variables
-    salutation = 'Hello'
+  # Private variables
+  salutation = 'Hello'
 
-    # Private constructor
-    class Greeter
-      @greet = ->
-        salutation
+  # Private constructor
+  class Greeter
+    @greet = ->
+      salutation
 
-    # Public API for configuration
-    @setSalutation = (s) ->
-      salutation = s
+  # Public API for configuration
+  @setSalutation = (s) ->
+    salutation = s
 
-    # Method for instantiating
-    @$get = ->
-      new Greeter()
+  # Method for instantiating
+  @$get = ->
+    new Greeter()
 
-    return
+  return

--- a/templates/provider/name.service.spec.coffee
+++ b/templates/provider/name.service.spec.coffee
@@ -3,12 +3,12 @@
 describe 'Service: <%= cameledName %>', ->
 
   # load the service's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
   <%= cameledName %> = undefined
-  beforeEach inject((_<%= cameledName %>_) ->
+  beforeEach inject (_<%= cameledName %>_) ->
     <%= cameledName %> = _<%= cameledName %>_
-  )
+
   it 'should do something', ->
     expect(!!<%= cameledName %>).toBe true

--- a/templates/route/name(ngroute).coffee
+++ b/templates/route/name(ngroute).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').config ($routeProvider) ->
+angular.module '<%= scriptAppName %>'
+.config ($routeProvider) ->
   $routeProvider.when '<%= route %>',
     templateUrl: '<%= htmlUrl %>'
     controller: '<%= classedName %>Ctrl'

--- a/templates/route/name(uirouter).coffee
+++ b/templates/route/name(uirouter).coffee
@@ -1,6 +1,7 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').config ($stateProvider) ->
+angular.module '<%= scriptAppName %>'
+.config ($stateProvider) ->
   $stateProvider.state '<%= name %>',
     url: '<%= route %>'
     templateUrl: '<%= htmlUrl %>'

--- a/templates/route/name.controller.coffee
+++ b/templates/route/name.controller.coffee
@@ -1,4 +1,5 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').controller '<%= classedName %>Ctrl', ($scope) ->
+angular.module '<%= scriptAppName %>'
+.controller '<%= classedName %>Ctrl', ($scope) ->
   $scope.message = 'Hello'

--- a/templates/route/name.controller.spec.coffee
+++ b/templates/route/name.controller.spec.coffee
@@ -3,16 +3,15 @@
 describe 'Controller: <%= classedName %>Ctrl', ->
 
   # load the controller's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
   <%= classedName %>Ctrl = undefined
   scope = undefined
 
   # Initialize the controller and a mock scope
-  beforeEach inject(($controller, $rootScope) ->
+  beforeEach inject ($controller, $rootScope) ->
     scope = $rootScope.$new()
-    <%= classedName %>Ctrl = $controller('<%= classedName %>Ctrl',
+    <%= classedName %>Ctrl = $controller '<%= classedName %>Ctrl',
       $scope: scope
-    )
-  )
+
   it 'should ...', ->
     expect(1).toEqual 1

--- a/templates/service/name.service.coffee
+++ b/templates/service/name.service.coffee
@@ -1,4 +1,5 @@
 'use strict'
 
-angular.module('<%= scriptAppName %>').service '<%= classedName %>', <%= classedName %> = ->
+angular.module '<%= scriptAppName %>'
+.service '<%= classedName %>', <%= classedName %> = ->
   # AngularJS will instantiate a singleton by calling 'new' on this function

--- a/templates/service/name.service.spec.coffee
+++ b/templates/service/name.service.spec.coffee
@@ -3,12 +3,12 @@
 describe 'Service: <%= classedName %>', ->
 
   # load the service's module
-  beforeEach module('<%= scriptAppName %>')
+  beforeEach module '<%= scriptAppName %>'
 
   # instantiate service
   <%= classedName %> = undefined
-  beforeEach inject((_<%= classedName %>_) ->
+  beforeEach inject (_<%= classedName %>_) ->
     <%= classedName %> = _<%= classedName %>_
-  )
+
   it 'should do something', ->
     expect(!!<%= classedName %>).toBe true


### PR DESCRIPTION
Style fixes to match better with [this](https://github.com/DaftMonk/generator-angular-fullstack/pull/351) 

Changes include:
- redundant parentheses removed
- double quotes changed to single quotes where possible
- angular methods are now consistently in a new line with same indentation level as their object
