### PR TITLE
fix(directive): fix template definition for webpack

### DIFF
--- a/templates/directiveComplex/name.directive.js
+++ b/templates/directiveComplex/name.directive.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 export default angular.module('<%= scriptAppName %>', [])
   .directive('<%= cameledName %>', function() {
     return {
-      <%_ if(filters.indexOf('webpack') > -1) { -%>
+      <%_ if(hasFilter('webpack')) { -%>
       template: require('./<%=name%>.<%=templateExt%>'),
       <%_ } else { -%>
       templateUrl: '<%= htmlUrl %>',

--- a/templates/directiveComplex/name.directive.js
+++ b/templates/directiveComplex/name.directive.js
@@ -4,7 +4,7 @@ const angular = require('angular');
 export default angular.module('<%= scriptAppName %>', [])
   .directive('<%= cameledName %>', function() {
     return {
-      <%_ if(filters.webpack) { -%>
+      <%_ if(filters.indexOf('webpack') > -1) { -%>
       template: require('./<%=name%>.<%=templateExt%>'),
       <%_ } else { -%>
       templateUrl: '<%= htmlUrl %>',


### PR DESCRIPTION
Apparently it expected a webpack object attribute as opposed to it being a value in an array. I saw from your code highlight that it was pushing everything into an array. Added an indexOf check instead.